### PR TITLE
chore: add issue templates for bug vs feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Do this thing
+2. Do this other thing
+3. click the submit button
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS/Architecture: [ubuntu 20.04] # Command: `uname -a`
+ - node version: # Command `node -v`
+ - pnpm version: # Command `pnpm -v`
+ - dockerized? # yes/no
+ - mobile/desktop?
+
+**Reproducible Code Snippet**
+```
+# Minimal code snippet to reproduce this bug
+```
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest an idea 
+title: ''
+labels: 'feature request'
+assignees: ''
+
+---
+**Did you search GitHub Issues and GitHub Discussions First?**
+Many users may find their feature is already being discussed. Help us keep duplicates to a minimum by searching for your feature first to see if it is already in progress.
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Are you willing and able to author this feature?**
+Are you comfortable developing this feature, along with appropriate testing, and submitting a PR that solves this feature request?
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

This will encourage users to write better tickets, and filter between bugs and features.

David, after merging, you still [have to enable these templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository) in the gui.

-r